### PR TITLE
change gwt version to 2.8.2, eclipse m2e error fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <java.version>1.8</java.version>
         <vavr.version>1.0.0-SNAPSHOT</vavr.version>
         <junit.version>4.12</junit.version>
-        <gwt.version>2.8.0</gwt.version>
+        <gwt.version>2.8.2</gwt.version>
         <maven.bundle.version>3.2.0</maven.bundle.version>
         <maven.install.version>2.5.2</maven.install.version>
         <maven.compiler.version>3.5.1</maven.compiler.version>
@@ -336,6 +336,19 @@
                                                 <versionRange>[0,)</versionRange>
                                                 <goals>
                                                     <goal>manifest</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>org.codehaus.mojo</groupId>
+                                                <artifactId>gwt-maven-plugin</artifactId>
+                                                <versionRange>[2.8.0,)</versionRange>
+                                                <goals>
+                                                    <goal>compile</goal>
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>


### PR DESCRIPTION
- changed gwt version to 2.8.2 as it uses an improved version of the JDT
  compiler with much faster type inference
- fixed m2e plugin execution not covered by lifecycle configuration error